### PR TITLE
feat: dual Zod schema, AbortSignal, fix messages, simplify Rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,7 @@ npm-debug.log*
 .cache
 
 # mkdocs build
-site/.claude/.arko/
+site/
+
+# claude
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcaelas/agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcaelas/agent",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcaelas/agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A small box of tools, which are implemented in different factions of the library.",
   "license": "ISC",
   "main": "build/index.js",

--- a/src/providers/claude-code.ts
+++ b/src/providers/claude-code.ts
@@ -122,9 +122,15 @@ function mcpFromTools(tools: Context["tools"], serverName: string) {
     version: "1.0.0",
     tools: tools.map((t) => {
       const j = t.toJSON();
-      const schema: Record<string, z.ZodString> = {};
-      for (const [k, v] of Object.entries(j.function.parameters.properties))
-        schema[k] = z.string().describe((v as any).description || k);
+      const isZod = t.parameters && typeof (t.parameters as any).parse === "function";
+      const schema: Record<string, any> = isZod
+        ? { ...(t.parameters as any).shape }
+        : Object.fromEntries(
+            Object.entries(j.function.parameters.properties ?? {}).map(([k, v]) => [
+              k,
+              z.string().describe((v as any).description || k),
+            ])
+          );
       return sdkTool(j.function.name, j.function.description || j.function.name, schema, async (args: any) => {
         try {
           const r = await t.func(null as any, args);

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -152,7 +152,7 @@ export default class Claude extends Function {
               input_schema: {
                 type: "object",
                 properties: json.function.parameters.properties,
-                required: Object.keys(json.function.parameters.properties),
+                required: json.function.parameters.required ?? Object.keys(json.function.parameters.properties ?? {}),
               },
             };
           })
@@ -178,14 +178,16 @@ export default class Claude extends Function {
       ...(stream && { stream: true }),
     });
 
-    return ((ctx: Context, opts?: { stream: true }): any => {
+    return ((ctx: Context, opts?: { stream?: true; signal?: AbortSignal }): any => {
       const payload = build_payload(ctx);
+      const signal = opts?.signal;
 
       if (!opts?.stream) {
         return (async (): Promise<ChatCompletionResponse> => {
           const response = await fetch(`${base_url}/messages`, {
             method: "POST",
             headers: build_headers(),
+            signal,
             body: JSON.stringify(build_body(payload, false)),
           });
 
@@ -245,6 +247,7 @@ export default class Claude extends Function {
         const response = await fetch(`${base_url}/messages`, {
           method: "POST",
           headers: build_headers(),
+          signal,
           body: JSON.stringify(build_body(payload, true)),
         });
 

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -112,14 +112,16 @@ export default class DeepSeek extends Function {
       ...(options.headers ?? {}),
     });
 
-    return ((ctx: Context, opts?: { stream: true }): any => {
+    return ((ctx: Context, opts?: { stream?: true; signal?: AbortSignal }): any => {
       const { messages, tools } = build_payload(ctx);
+      const signal = opts?.signal;
 
       if (!opts?.stream) {
         return (async (): Promise<ChatCompletionResponse> => {
           const response = await fetch(`${base_url}/chat/completions`, {
             method: "POST",
             headers: build_headers(),
+            signal,
             body: JSON.stringify({
               model: options.model,
               messages,
@@ -141,6 +143,7 @@ export default class DeepSeek extends Function {
         const response = await fetch(`${base_url}/chat/completions`, {
           method: "POST",
           headers: build_headers(),
+          signal,
           body: JSON.stringify({
             model: options.model,
             messages,

--- a/src/providers/groq.ts
+++ b/src/providers/groq.ts
@@ -112,14 +112,16 @@ export default class Groq extends Function {
       ...(options.headers ?? {}),
     });
 
-    return ((ctx: Context, opts?: { stream: true }): any => {
+    return ((ctx: Context, opts?: { stream?: true; signal?: AbortSignal }): any => {
       const { messages, tools } = build_payload(ctx);
+      const signal = opts?.signal;
 
       if (!opts?.stream) {
         return (async (): Promise<ChatCompletionResponse> => {
           const response = await fetch(`${base_url}/chat/completions`, {
             method: "POST",
             headers: build_headers(),
+            signal,
             body: JSON.stringify({
               model: options.model,
               messages,
@@ -141,6 +143,7 @@ export default class Groq extends Function {
         const response = await fetch(`${base_url}/chat/completions`, {
           method: "POST",
           headers: build_headers(),
+          signal,
           body: JSON.stringify({
             model: options.model,
             messages,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -110,14 +110,16 @@ export default class OpenAI extends Function {
       ...(options.headers ?? {}),
     });
 
-    return ((ctx: Context, opts?: { stream: true }): any => {
+    return ((ctx: Context, opts?: { stream?: true; signal?: AbortSignal }): any => {
       const { messages, tools } = build_payload(ctx);
+      const signal = opts?.signal;
 
       if (!opts?.stream) {
         return (async (): Promise<ChatCompletionResponse> => {
           const response = await fetch(`${base_url}/chat/completions`, {
             method: "POST",
             headers: build_headers(),
+            signal,
             body: JSON.stringify({
               model: options.model,
               messages,
@@ -139,6 +141,7 @@ export default class OpenAI extends Function {
         const response = await fetch(`${base_url}/chat/completions`, {
           method: "POST",
           headers: build_headers(),
+          signal,
           body: JSON.stringify({
             model: options.model,
             messages,

--- a/src/static/agent.ts
+++ b/src/static/agent.ts
@@ -263,8 +263,8 @@ export type StreamInput = string | Message | { role: "user" | "assistant"; conte
  * Con { stream: true }: retorna AsyncIterable de ProviderChunk (streaming).
  */
 export type Provider = {
-  (ctx: Context): ChatCompletionResponse | Promise<ChatCompletionResponse>;
-  (ctx: Context, opts: { stream: true }): AsyncIterable<ProviderChunk>;
+  (ctx: Context, opts?: { signal?: AbortSignal }): ChatCompletionResponse | Promise<ChatCompletionResponse>;
+  (ctx: Context, opts: { stream: true; signal?: AbortSignal }): AsyncIterable<ProviderChunk>;
 };
 
 /**
@@ -679,7 +679,7 @@ export default class Agent {
    * }
    * ```
    */
-  async *stream(input: StreamInput): AsyncGenerator<StreamChunk, void, unknown> {
+  async *stream(input: StreamInput, opts?: { signal?: AbortSignal }): AsyncGenerator<StreamChunk, void, unknown> {
     const message =
       input instanceof Message
         ? input
@@ -687,7 +687,7 @@ export default class Agent {
           ? new Message({ role: "user", content: input })
           : new Message(input as any);
 
-    this._context.messages = this._context.messages.concat(message);
+    this._context.appendMessages(message);
 
     const PROVIDERS: Provider[] = [...this._providers];
     const FALLBACK: Provider[] = [];
@@ -696,12 +696,14 @@ export default class Agent {
     let iteration = 0;
 
     while ((PROVIDERS.length || FALLBACK.length) && iteration++ < MAX_LOOPS) {
+      if (opts?.signal?.aborted) return;
+
       const provider =
         PROVIDERS[Math.floor(Math.random() * PROVIDERS.length)] ??
         FALLBACK[Math.floor(Math.random() * FALLBACK.length)];
 
       try {
-        const chunks = provider!(this._context, { stream: true });
+        const chunks = provider!(this._context, { stream: true, signal: opts?.signal });
 
         let text_content = "";
         const tool_calls_acc: Map<number, { id: string; name: string; arguments: string }> = new Map();
@@ -730,7 +732,7 @@ export default class Agent {
             function: { name: tc.name, arguments: tc.arguments },
           }));
 
-          this._context.messages = this._context.messages.concat(
+          this._context.appendMessages(
             new Message({
               role: "assistant",
               content: text_content || null,
@@ -760,7 +762,7 @@ export default class Agent {
           );
 
           for (const r of results) {
-            this._context.messages = this._context.messages.concat(
+            this._context.appendMessages(
               new Message({ role: "tool", tool_call_id: r.id, content: r.content })
             );
             yield { role: "tool", name: r.name, tool_call_id: r.id, content: r.content };
@@ -770,7 +772,7 @@ export default class Agent {
         }
 
         if (text_content) {
-          this._context.messages = this._context.messages.concat(
+          this._context.appendMessages(
             new Message({ role: "assistant", content: text_content })
           );
         }
@@ -826,8 +828,8 @@ export default class Agent {
    * // 5. Responde al usuario
    * ```
    */
-  async call(prompt: string): Promise<[Message[], boolean]> {
-    this._context.messages = this._context.messages.concat(
+  async call(prompt: string, opts?: { signal?: AbortSignal }): Promise<[Message[], boolean]> {
+    this._context.appendMessages(
       new Message({
         role: "user",
         content: prompt,
@@ -838,15 +840,17 @@ export default class Agent {
     const TOOLS = this._context.tools;
 
     while (PROVIDERS.length || FALLBACK.length) {
+      if (opts?.signal?.aborted) return [this._context.messages, false];
+
       let success = true;
       const provider =
         PROVIDERS[Math.floor(Math.random() * PROVIDERS.length)] ??
         FALLBACK[Math.floor(Math.random() * FALLBACK.length)];
       try {
-        const response = await provider!(this._context);
+        const response = await provider!(this._context, opts?.signal ? { signal: opts.signal } : undefined);
         for (const choice of response.choices) {
           if (choice.message.content) {
-            this._context.messages = this._context.messages.concat(
+            this._context.appendMessages(
               new Message({
                 role: "assistant",
                 content: choice.message.content,
@@ -856,8 +860,7 @@ export default class Agent {
           if ((choice.message.tool_calls ?? []).length) {
             success = false;
 
-            // Añadir mensaje assistant con tool_calls al historial
-            this._context.messages = this._context.messages.concat(
+            this._context.appendMessages(
               new Message({
                 role: "assistant",
                 content: null,
@@ -921,9 +924,8 @@ export default class Agent {
               )
             );
 
-            // Añadir resultados de las herramientas al historial
-            this._context.messages = this._context.messages.concat(
-              _calls.map((c) => new Message(c))
+            this._context.appendMessages(
+              ..._calls.map((c) => new Message(c))
             );
           }
         }

--- a/src/static/context.ts
+++ b/src/static/context.ts
@@ -433,4 +433,26 @@ export default class Context {
     this._messages.length = 0; // Limpiar array existente
     this._messages.push(...messages.filter((m) => m instanceof Message));
   }
+
+  /**
+   * @description
+   * Appends messages to the local messages array without triggering the getter/setter cycle.
+   * Prevents parent message duplication that occurs when using the messages setter.
+   *
+   * Agrega mensajes al array local de mensajes sin disparar el ciclo getter/setter.
+   * Previene la duplicacion de mensajes padre que ocurre al usar el setter de messages.
+   *
+   * @param messages Messages to append / Mensajes a agregar
+   *
+   * @example
+   * ```typescript
+   * context.appendMessages(
+   *   new Message({ role: "user", content: "Hello" }),
+   *   new Message({ role: "assistant", content: "Hi!" })
+   * );
+   * ```
+   */
+  appendMessages(...messages: Message[]): void {
+    this._messages.push(...messages.filter((m) => m instanceof Message));
+  }
 }

--- a/src/static/rule.ts
+++ b/src/static/rule.ts
@@ -1,182 +1,80 @@
 /**
  * @fileoverview
- * Sistema de reglas dinámicas para agentes de IA.
+ * Behavior rules system for AI agents.
+ * Sistema de reglas de comportamiento para agentes de IA.
  *
- * Este módulo proporciona la clase Rule que define comportamientos, restricciones
- * y personalidad de forma dinámica y condicional. Las reglas se evalúan en tiempo
- * de ejecución basándose en el estado del contexto y pueden aplicarse o no según
- * condiciones específicas.
+ * This module provides the Rule class that defines behaviors, constraints
+ * and guidelines for agents. Rules are injected as system context in each request.
+ *
+ * Este modulo proporciona la clase Rule que define comportamientos, restricciones
+ * y directrices para agentes. Las reglas se inyectan como contexto del sistema en cada peticion.
  *
  * @author Arcaelas Insiders
- * @version 2.0.0
+ * @version 3.0.0
  * @since 2.0.0
  *
  * @example
  * ```typescript
- * // Regla simple
- * const politeness = new Rule("Mantén siempre un tono profesional y cordial");
- *
- * // Regla condicional programática
- * const business_hours = new Rule("Informar sobre horario de atención telefónica", {
- *   when: (agent) => {
- *     const now = new Date();
- *     const hour = now.getHours();
- *     return hour < 9 || hour > 17;
- *   }
- * });
- *
- * // Regla condicional programática
- * const premium_support = new Rule("Ofrecer soporte prioritario y beneficios premium", {
- *   when: (agent) => {
- *     const tier = agent.metadata.get("customer_tier", "");
- *     return tier === "gold" || tier === "platinum";
- *   }
- * });
+ * const politeness = new Rule("Manten siempre un tono profesional y cordial");
+ * const privacy = new Rule("Nunca compartir informacion personal de usuarios");
  * ```
  */
 
-import type Agent from "./agent";
-
 /**
  * @description
- * Opciones para configuración de reglas condicionales.
- */
-export interface RuleOptions {
-  /**
-   * @description
-   * Función que determina cuándo se aplica la regla.
-   * Recibe el agente y retorna un booleano.
-   * Puede ser async o síncrona.
-   */
-  when: (ctx: Agent) => boolean | Promise<boolean>;
-}
-
-/**
- * @description
- * Clase Rule que define comportamientos dinámicos y restricciones para agentes.
- *
- * Las reglas pueden ser estáticas (siempre activas) o condicionales (evaluadas
- * dinámicamente). Las reglas condicionales pueden usar descripciones textuales
- * para que el modelo de IA interprete cuándo aplicarlas, o funciones programáticas
- * que evalúan el contexto actual.
+ * Behavior rule defining agent constraints and guidelines.
+ * Regla de comportamiento que define restricciones y directrices del agente.
  *
  * @example
  * ```typescript
- * // Regla estática siempre activa
- * const privacy = new Rule("Nunca compartir información personal de usuarios");
+ * const privacy = new Rule("Nunca compartir informacion personal de usuarios");
+ * const security = new Rule("NUNCA proporciones tokens API o datos sensibles");
  *
- * // Regla con condición específica
- * const escalation = new Rule("Escalar a supervisor humano", {
- *   when: (agent) => {
- *     const messages = agent.messages;
- *     const recent_msg = messages[messages.length - 1]?.content || "";
- *     return recent_msg.includes("supervisor") || recent_msg.includes("frustrado");
- *   }
- * });
+ * agent.rules = [privacy, security];
  *
- * // Regla con condición programática
- * const region_specific = new Rule("Aplicar regulaciones GDPR", {
- *   when: (agent) => {
- *     const region = agent.metadata.get("user_region", "");
- *     return region === "EU" || region === "UK";
- *   }
- * });
- *
- * // Regla con lógica compleja
- * const working_hours = new Rule("Ofrecer callback durante horario laboral", {
- *   when: (agent) => {
- *     const now = new Date();
- *     const hour = now.getHours();
- *     const is_weekend = now.getDay() === 0 || now.getDay() === 6;
- *     return (hour < 9 || hour > 17 || is_weekend);
- *   }
- * });
- *
- * // Uso de las reglas
- * console.log(privacy.description);    // "Nunca compartir información..."
- * console.log(privacy.length);         // 45 (caracteres)
- * console.log(typeof privacy.when);    // "function"
+ * console.log(privacy.description);  // "Nunca compartir informacion personal de usuarios"
+ * console.log(privacy.length);       // 52
  * ```
  */
 export default class Rule {
   /**
    * @description
-   * Descripción textual de la regla que define el comportamiento esperado.
+   * Textual description of the rule defining expected behavior.
+   * Descripcion textual de la regla que define el comportamiento esperado.
    */
   readonly description: string;
 
   /**
    * @description
-   * Función que determina cuándo aplicar la regla.
-   * Siempre es una función que recibe el agente.
-   * Por defecto retorna true (regla siempre activa).
-   */
-  readonly when: (ctx: Agent) => boolean | Promise<boolean>;
-
-  /**
-   * @description
-   * Crea una regla simple que siempre está activa.
+   * Creates a new Rule instance.
+   * Crea una nueva instancia de Rule.
    *
-   * @param description Descripción del comportamiento que define la regla
+   * @param description - Rule text defining the expected behavior
    *
    * @example
    * ```typescript
-   * const politeness = new Rule("Mantén un tono respetuoso en todas las interacciones");
-   * const confidentiality = new Rule("No divulgar información confidencial de la empresa");
-   * const helpfulness = new Rule("Proporcionar respuestas útiles y completas");
+   * const politeness = new Rule("Manten un tono respetuoso en todas las interacciones");
+   * const confidentiality = new Rule("No divulgar informacion confidencial de la empresa");
    * ```
    */
-  constructor(description: string);
-
-  /**
-   * @description
-   * Crea una regla condicional que se aplica según condiciones específicas.
-   *
-   * @param description Descripción del comportamiento que define la regla
-   * @param options Opciones de configuración incluyendo la condición
-   *
-   * @example
-   * ```typescript
-   * // Condición programática con acceso al contexto del agente
-   * const upsell = new Rule("Sugerir productos premium complementarios", {
-   *   when: (agent) => {
-   *     const tier = agent.metadata.get("customer_tier", "");
-   *     return tier === "premium" || tier === "gold";
-   *   }
-   * });
-   *
-   * // Condición asíncrona con evaluación compleja
-   * const loyalty_discount = new Rule("Aplicar descuento por lealtad del 15%", {
-   *   when: async (agent) => {
-   *     const purchases = agent.metadata.get("total_purchases", "0");
-   *     const member_since = agent.metadata.get("member_since", "");
-   *     const years_since = member_since ?
-   *       (Date.now() - new Date(member_since).getTime()) / (1000 * 60 * 60 * 24 * 365) : 0;
-   *     return parseInt(purchases) > 10 && years_since > 2;
-   *   }
-   * });
-   * ```
-   */
-  constructor(description: string, options: RuleOptions);
-
-  constructor(description: string, options?: RuleOptions) {
+  constructor(description: string) {
     this.description = description;
-    this.when = options?.when || (() => true); // Valor predeterminado: siempre activa
     if (!this.description || this.description.trim().length === 0) {
-      throw new Error("La descripción de la regla es requerida y no puede estar vacía");
+      throw new Error("La descripcion de la regla es requerida y no puede estar vacia");
     }
   }
 
   /**
    * @description
-   * Obtiene la longitud de la descripción de la regla.
+   * Gets the length of the rule description.
+   * Obtiene la longitud de la descripcion de la regla.
    *
-   * @returns Número de caracteres en la descripción
+   * @returns Number of characters in the description / Numero de caracteres en la descripcion
    *
    * @example
    * ```typescript
    * const rule = new Rule("Mantener tono profesional");
-   * console.log(rule.length); // 24
+   * console.log(rule.length); // 25
    * ```
    */
   get length(): number {
@@ -185,49 +83,32 @@ export default class Rule {
 
   /**
    * @description
-   * Convierte la regla a formato JSON para serialización.
-   * Implementa el método nativo toJSON() de Node.js para compatibilidad
-   * con JSON.stringify() y otras operaciones de serialización.
+   * Converts the rule to JSON format for serialization.
+   * Convierte la regla a formato JSON para serializacion.
    *
-   * @returns Representación JSON de la regla
+   * @returns JSON representation of the rule / Representacion JSON de la regla
    *
    * @example
    * ```typescript
-   * const rule = new Rule("Ser educado", {
-   *   when: (agent) => agent.metadata.get("user_type", "") === "customer"
-   * });
-   *
-   * const rule_data = rule.toJSON();
-   * console.log(JSON.stringify(rule)); // Usa automáticamente toJSON()
-   * // Resultado: { "description": "Ser educado", "when": "[Function]" }
+   * const rule = new Rule("Ser educado");
+   * console.log(JSON.stringify(rule)); // { "description": "Ser educado" }
    * ```
    */
-  toJSON(): {
-    description: string;
-    when: string; // Siempre indicamos que es función
-  } {
-    return {
-      description: this.description,
-      when: "[Function]", // when siempre es función
-    };
+  toJSON(): { description: string } {
+    return { description: this.description };
   }
 
   /**
    * @description
-   * Retorna representación string de la regla para debugging.
+   * Returns string representation of the rule for debugging.
+   * Retorna representacion string de la regla para debugging.
    *
-   * @returns Descripción legible de la regla
+   * @returns Readable description of the rule / Descripcion legible de la regla
    *
    * @example
    * ```typescript
-   * const static_rule = new Rule("Ser educado");
-   * const conditional_rule = new Rule("Ofrecer ayuda", {
-   *   when: (agent) => agent.messages.length > 0
-   * });
-   *
-   * console.log(static_rule.toString());     // "Rule: Ser educado [Function]"
-   * console.log(conditional_rule.toString()); // "Rule: Ofrecer ayuda [Function]"
-   * console.log(String(static_rule));        // Usa automáticamente toString()
+   * const rule = new Rule("Ser educado");
+   * console.log(String(rule)); // "Rule: Ser educado"
    * ```
    */
   toString(): string {
@@ -235,8 +116,6 @@ export default class Rule {
       this.description.length > 50
         ? this.description.substring(0, 47) + "..."
         : this.description;
-
-    // Ahora when siempre es función
-    return `Rule: ${preview} [Function]`;
+    return `Rule: ${preview}`;
   }
 }

--- a/src/static/tool.ts
+++ b/src/static/tool.ts
@@ -1,181 +1,184 @@
 /**
  * @fileoverview
- * Sistema de herramientas modulares para agentes de IA.
- *
- * Este módulo proporciona la clase Tool que encapsula funcionalidades específicas
- * que los agentes pueden ejecutar durante conversaciones. Las herramientas son
- * completamente reutilizables entre diferentes contextos y agentes.
+ * Modular tool system for AI agents with dual schema support (Record and Zod).
+ * Sistema de herramientas modulares para agentes de IA con soporte dual de schema (Record y Zod).
  *
  * @author Arcaelas Insiders
- * @version 2.0.0
+ * @version 3.0.0
  * @since 2.0.0
  *
  * @example
  * ```typescript
- * // Herramienta simple
- * const weather = new Tool('get_weather', (agent: Agent, input: string) => {
- *   return "Sunny, 24°C";
+ * // Simple tool / Herramienta simple
+ * const weather = new Tool('get_weather', (agent, input) => "Sunny, 24C");
+ *
+ * // Record parameters (legacy) / Parametros Record (legacy)
+ * const customer = new Tool('find_customer', {
+ *   description: 'Buscar cliente por email',
+ *   parameters: { email: 'Email del cliente' },
+ *   func: (agent, { email }) => database.find(email),
  * });
  *
- * // Herramienta avanzada
- * const customer = new Tool('find_customer', {
- *   description: 'Buscar información de cliente en la base de datos',
- *   parameters: {
- *     email: 'Email del cliente a buscar',
- *     include_history: 'Incluir historial de transacciones (true/false)'
- *   },
- *   func: (agent, { email, include_history }) => {
- *     return database.find(email, include_history === 'true');
- *   }
+ * // Zod parameters (typed) / Parametros Zod (tipados)
+ * import { z } from 'zod';
+ * const search = new Tool('search', {
+ *   description: 'Buscar productos',
+ *   parameters: z.object({
+ *     query: z.string().describe('Termino de busqueda'),
+ *     limit: z.number().optional().describe('Maximo de resultados'),
+ *   }),
+ *   func: (agent, { query, limit }) => catalog.search(query, limit),
  * });
  * ```
  */
 
 import Agent from "./agent";
+import { z } from "zod";
 
 /**
  * @description
- * Opciones para configuración avanzada de herramientas.
- * @template T Tipo de parámetros de la herramienta
+ * Infers the parameter type for func based on the schema type.
+ * If T is a ZodType, infers the output type. Otherwise uses T directly.
+ *
+ * Infiere el tipo de parametros para func basado en el tipo de schema.
+ * Si T es ZodType, infiere el tipo de salida. De lo contrario usa T directamente.
+ */
+export type InferParams<T> = T extends z.ZodType<infer O> ? O : T extends object ? T : { input: string };
+
+/**
+ * @description
+ * Advanced tool configuration options.
+ * Opciones de configuracion avanzada de herramientas.
+ *
+ * @template T - Parameter type: Record<string, string> for legacy or z.ZodObject for typed schemas
  */
 export interface ToolOptions<T = Record<string, string>> {
   /**
    * @description
-   * Descripción clara de lo que hace la herramienta.
+   * Clear description of what the tool does.
+   * Descripcion clara de lo que hace la herramienta.
    */
   description: string;
 
   /**
    * @description
-   * Esquema de parámetros donde cada clave es el nombre del parámetro
-   * y cada valor es la descripción de ese parámetro.
+   * Parameter schema. Accepts either a Record<string, string> where values are descriptions,
+   * or a Zod schema for typed validation and rich JSON Schema generation.
+   *
+   * Esquema de parametros. Acepta un Record<string, string> donde los valores son descripciones,
+   * o un schema Zod para validacion tipada y generacion de JSON Schema rico.
    */
   parameters?: T;
 
   /**
    * @description
-   * Función que se ejecuta cuando la herramienta es llamada.
-   * Puede retornar cualquier valor serializable.
-   * Puede ser síncrona o asíncrona.
+   * Function executed when the tool is called. Can be sync or async.
+   * Funcion ejecutada cuando la herramienta es llamada. Puede ser sincrona o asincrona.
    */
-  func(agent: Agent, params: T extends object ? T : { input: string }): any;
+  func(agent: Agent, params: InferParams<T>): any;
 }
 
 /**
  * @description
- * Función simple para herramientas básicas.
+ * Simple handler function for basic tools.
+ * Funcion handler simple para herramientas basicas.
  */
 export type SimpleToolHandler = (agent: Agent, input: string) => any;
 
 /**
  * @description
- * Clase Tool que encapsula funcionalidades ejecutables por agentes de IA.
+ * Tool class encapsulating executable functions for AI agents.
+ * Supports dual schema: Record<string, string> (legacy) and Zod (typed).
  *
- * Las herramientas pueden ser simples (con entrada string) o avanzadas
- * (con parámetros tipados y validación). Son completamente reutilizables
- * entre diferentes contextos y agentes.
+ * Clase Tool que encapsula funciones ejecutables para agentes de IA.
+ * Soporta schema dual: Record<string, string> (legacy) y Zod (tipado).
  *
  * @example
  * ```typescript
- * // Herramienta simple para obtener timestamp
- * const timestamp = new Tool('get_timestamp', (agent: Agent, input: string) => {
- *   return new Date().toISOString();
+ * // Record schema (all params as strings)
+ * const ping = new Tool('ping', {
+ *   description: 'Ping a host',
+ *   parameters: { host: 'Host to ping' },
+ *   func: (agent, { host }) => `Pong from ${host}`,
  * });
  *
- * // Herramienta avanzada para búsqueda de productos
- * const product_search = new Tool('search_products', {
- *   description: 'Buscar productos en el catálogo con filtros avanzados',
- *   parameters: {
- *     query: 'Términos de búsqueda',
- *     category: 'Categoría específica (opcional)',
- *     max_price: 'Precio máximo (opcional)'
+ * // Zod schema (typed params)
+ * const calc = new Tool('calculate', {
+ *   description: 'Basic math',
+ *   parameters: z.object({
+ *     a: z.number().describe('First number'),
+ *     b: z.number().describe('Second number'),
+ *     op: z.enum(['+', '-', '*', '/']).describe('Operation'),
+ *   }),
+ *   func: (agent, { a, b, op }) => {
+ *     switch (op) {
+ *       case '+': return a + b;
+ *       case '-': return a - b;
+ *       case '*': return a * b;
+ *       case '/': return b !== 0 ? a / b : 'Division by zero';
+ *     }
  *   },
- *   func: (agent, { query, category, max_price }) => {
- *     return data_service.search({
- *       query,
- *       category: category || null,
- *       max_price: max_price ? parseFloat(max_price) : null
- *     });
- *   }
  * });
- *
- * // Uso de las herramientas
- * console.log(timestamp.name); // 'get_timestamp'
- * console.log(product_search.description); // 'Buscar productos...'
  * ```
  */
 export default class Tool<T = any> {
   /**
    * @description
-   * Nombre único de la herramienta.
+   * Unique name of the tool.
+   * Nombre unico de la herramienta.
    */
   readonly name: string;
 
   /**
    * @description
-   * Descripción de lo que hace la herramienta.
+   * Description of what the tool does.
+   * Descripcion de lo que hace la herramienta.
    */
   readonly description: string;
 
   /**
    * @description
-   * Esquema de parámetros de la herramienta.
+   * Parameter schema (Record or Zod).
+   * Esquema de parametros (Record o Zod).
    */
   readonly parameters: T | { input: string };
 
   /**
    * @description
-   * Función ejecutable de la herramienta.
+   * Executable function of the tool.
+   * Funcion ejecutable de la herramienta.
    */
-  readonly func: (
-    agent: Agent,
-    params: T extends object ? T : { input: string }
-  ) => any;
+  readonly func: (agent: Agent, params: InferParams<T>) => any;
 
   /**
    * @description
+   * Creates a simple tool with string input.
    * Crea una herramienta simple con entrada string.
    *
-   * @param name Nombre único de la herramienta
-   * @param handler Función que procesa la entrada y retorna el resultado
+   * @param name - Unique tool name / Nombre unico de la herramienta
+   * @param handler - Function processing input / Funcion que procesa la entrada
    *
    * @example
    * ```typescript
-   * const weather = new Tool('get_weather', (agent: Agent, input: string) => {
-   *   // input contiene la consulta del usuario
-   *   return "Sunny, 24°C in Madrid";
-   * });
+   * const weather = new Tool('get_weather', (agent, input) => "Sunny, 24C");
    * ```
    */
   constructor(name: string, handler: SimpleToolHandler);
 
   /**
    * @description
-   * Crea una herramienta avanzada con parámetros tipados.
+   * Creates an advanced tool with typed parameters.
+   * Crea una herramienta avanzada con parametros tipados.
    *
-   * @param name Nombre único de la herramienta
-   * @param options Configuración avanzada de la herramienta
+   * @param name - Unique tool name / Nombre unico de la herramienta
+   * @param options - Advanced configuration / Configuracion avanzada
    *
    * @example
    * ```typescript
-   * const calculator = new Tool('calculate', {
-   *   description: 'Realizar cálculos matemáticos básicos',
-   *   parameters: {
-   *     operation: 'Operación a realizar (+, -, *, /)',
-   *     a: 'Primer número',
-   *     b: 'Segundo número'
-   *   },
-   *   func: (agent, { operation, a, b }) => {
-   *     const num_a = parseFloat(a);
-   *     const num_b = parseFloat(b);
-   *     switch (operation) {
-   *       case '+': return num_a + num_b;
-   *       case '-': return num_a - num_b;
-   *       case '*': return num_a * num_b;
-   *       case '/': return num_b !== 0 ? num_a / num_b : 'Error: División por cero';
-   *       default: return 'Operación no válida';
-   *     }
-   *   }
+   * const search = new Tool('search', {
+   *   description: 'Search products',
+   *   parameters: z.object({ query: z.string().describe('Search term') }),
+   *   func: (agent, { query }) => catalog.search(query),
    * });
    * ```
    */
@@ -202,17 +205,19 @@ export default class Tool<T = any> {
 
   /**
    * @description
-   * Convierte la herramienta a formato JSON para serialización.
-   * Implementa el método nativo toJSON() de Node.js para compatibilidad
-   * con JSON.stringify() y otras operaciones de serialización.
+   * Converts the tool to JSON format for API serialization.
+   * Auto-detects Zod schemas and generates rich JSON Schema with proper types.
+   * Legacy Record schemas generate string-only properties with all params required.
    *
-   * @returns Representación JSON de la herramienta
+   * Convierte la herramienta a formato JSON para serializacion API.
+   * Auto-detecta schemas Zod y genera JSON Schema rico con tipos correctos.
+   * Schemas Record legacy generan propiedades tipo string con todos los params requeridos.
+   *
+   * @returns JSON representation compatible with OpenAI tool calling format
    *
    * @example
    * ```typescript
-   * const tool_data = tool.toJSON();
-   * console.log(JSON.stringify(tool)); // Usa automáticamente toJSON()
-   * // Resultado: { name: 'get_weather', description: '...', parameters: {...} }
+   * console.log(JSON.stringify(tool)); // uses toJSON() automatically
    * ```
    */
   toJSON(): {
@@ -220,42 +225,49 @@ export default class Tool<T = any> {
     function: {
       name: string;
       description: string;
-      parameters: {
-        type: "object";
-        properties: T | { input: string };
-      };
+      parameters: Record<string, any>;
     };
   } {
-    const parameters = {};
-    for (const k in this.parameters!) {
-      parameters[k] = {
-        type: "string",
-        description: this.parameters[k],
+    if (this.parameters && typeof (this.parameters as any).parse === "function") {
+      const { $schema, ...schema } = z.toJSONSchema(this.parameters as unknown as z.ZodType) as Record<string, any>;
+      return {
+        type: "function",
+        function: {
+          name: this.name,
+          description: this.description,
+          parameters: schema,
+        },
       };
+    }
+    const properties: Record<string, any> = {};
+    const required: string[] = [];
+    for (const k in this.parameters!) {
+      properties[k] = {
+        type: "string",
+        description: (this.parameters as any)[k],
+      };
+      required.push(k);
     }
     return {
       type: "function",
       function: {
         name: this.name,
         description: this.description,
-        parameters: {
-          type: "object",
-          properties: parameters as any,
-        },
+        parameters: { type: "object", properties, required },
       },
     };
   }
 
   /**
    * @description
-   * Retorna representación string de la herramienta para debugging.
+   * Returns string representation of the tool for debugging.
+   * Retorna representacion string de la herramienta para debugging.
    *
-   * @returns Descripción legible de la herramienta
+   * @returns Readable description / Descripcion legible
    *
    * @example
    * ```typescript
-   * console.log(tool.toString()); // "Tool(get_weather): Friendly weather assistant"
-   * console.log(String(tool));    // Usa automáticamente toString()
+   * console.log(String(tool)); // "Tool(get_weather): Friendly weather assistant"
    * ```
    */
   toString(): string {


### PR DESCRIPTION
## Cambios

- **Fix**: Duplicacion de mensajes con parent contexts — `appendMessages()` reemplaza el ciclo getter/setter que duplicaba mensajes heredados en cada turno
- **Simplificacion**: Eliminar `when()` de Rule (dead code, ningun provider lo evaluaba)
- **Feature**: Soporte dual de schema en Tool — acepta `Record<string, string>` (legacy) y `z.ZodObject` con deteccion automatica, inferencia de tipos y JSON Schema rico via `z.toJSONSchema()`
- **Feature**: AbortSignal en `call()` y `stream()` propagado a todos los providers HTTP (OpenAI, Groq, DeepSeek, Claude)

Closes #20